### PR TITLE
bug fix: NotImplementedError when constructing CharacterTokenizer

### DIFF
--- a/charactertokenizer/core.py
+++ b/charactertokenizer/core.py
@@ -41,6 +41,18 @@ class CharacterTokenizer(PreTrainedTokenizer):
 
         mask_token = AddedToken("[MASK]", lstrip=True, rstrip=False)
 
+        self._vocab_str_to_int = {
+            "[CLS]": 0,
+            "[SEP]": 1,
+            "[BOS]": 2,
+            "[MASK]": 3,
+            "[PAD]": 4,
+            "[RESERVED]": 5,
+            "[UNK]": 6,
+            **{ch: i + 7 for i, ch in enumerate(characters)},
+        }
+        self._vocab_int_to_str = {v: k for k, v in self._vocab_str_to_int.items()}
+
         super().__init__(
             bos_token=bos_token,
             eos_token=eos_token,
@@ -54,21 +66,12 @@ class CharacterTokenizer(PreTrainedTokenizer):
             **kwargs,
         )
 
-        self._vocab_str_to_int = {
-            "[CLS]": 0,
-            "[SEP]": 1,
-            "[BOS]": 2,
-            "[MASK]": 3,
-            "[PAD]": 4,
-            "[RESERVED]": 5,
-            "[UNK]": 6,
-            **{ch: i + 7 for i, ch in enumerate(characters)},
-        }
-        self._vocab_int_to_str = {v: k for k, v in self._vocab_str_to_int.items()}
-
     @property
     def vocab_size(self) -> int:
         return len(self._vocab_str_to_int)
+
+    def get_vocab(self):
+        return self._vocab_str_to_int
 
     def _tokenize(self, text: str) -> List[str]:
         return list(text)


### PR DESCRIPTION
# Abstract

Under `transformers==4.41.2`, constructing `CharacterTokenizer` raises `NotImplementedError`.

# Minimal reproducible example

Command to reproduce the error (from command line), plus the error output:

```
$ python3 -c "from charactertokenizer import CharacterTokenizer; _ = CharacterTokenizer('abc', 1024)"

Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/user/Documents/Projects/python3/proj/dariush-bahrami+character-tokenizer/charactertokenizer/core.py", line 44, in __init__
    super().__init__(
  File "/Users/user/Documents/Projects/python3/proj/dariush-bahrami+character-tokenizer/venv/lib/python3.9/site-packages/transformers/tokenization_utils.py", line 367, in __init__
    self._add_tokens(
  File "/Users/user/Documents/Projects/python3/proj/dariush-bahrami+character-tokenizer/venv/lib/python3.9/site-packages/transformers/tokenization_utils.py", line 467, in _add_tokens
    current_vocab = self.get_vocab().copy()
  File "/Users/user/Documents/Projects/python3/proj/dariush-bahrami+character-tokenizer/venv/lib/python3.9/site-packages/transformers/tokenization_utils_base.py", line 1682, in get_vocab
    raise NotImplementedError()
NotImplementedError
```

which is caused by not implementing the `get_vocab()` method required by the super class.

# My fix

In order to fix the error, I add the required `get_vocab()` method, and adjust several statements in `__init__()` in order to get `get_vocab()` work.